### PR TITLE
Fix: use modular SDK function syntax for Firebase auth

### DIFF
--- a/firebase.js
+++ b/firebase.js
@@ -1,6 +1,12 @@
 // Firebase configuration
 import { initializeApp } from "https://www.gstatic.com/firebasejs/9.22.0/firebase-app.js";
-import { getAuth } from "https://www.gstatic.com/firebasejs/9.22.0/firebase-auth.js";
+import { 
+  getAuth,
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut
+} from "https://www.gstatic.com/firebasejs/9.22.0/firebase-auth.js";
 import { getFirestore } from "https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js";
 
 const firebaseConfig = {
@@ -15,4 +21,4 @@ const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const db = getFirestore(app);
 
-export { auth, db };
+export { auth, db, onAuthStateChanged, signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut };

--- a/login.js
+++ b/login.js
@@ -1,7 +1,7 @@
-import { auth } from './firebase.js';
+import { auth, onAuthStateChanged, signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut } from './firebase.js';
 
 // Check if user is logged in
-auth.onAuthStateChanged((user) => {
+onAuthStateChanged(auth, (user) => {
   if (user) {
     document.getElementById("authSection").style.display = "none";
     document.getElementById("logoutSection").style.display = "block";
@@ -17,7 +17,7 @@ async function login() {
   const password = document.getElementById("password").value;
 
   try {
-    const result = await auth.signInWithEmailAndPassword(email, password);
+    const result = await signInWithEmailAndPassword(auth, email, password);
     console.log("✅ Logged in as:", result.user.email);
     window.location.href = "index.html";
   } catch (err) {
@@ -42,7 +42,7 @@ async function signup() {
   }
 
   try {
-    const result = await auth.createUserWithEmailAndPassword(email, password);
+    const result = await createUserWithEmailAndPassword(auth, email, password);
     console.log("✅ Account created:", result.user.email);
     alert("Account created successfully! You can now log in.");
     toggleSignup();
@@ -55,11 +55,12 @@ async function signup() {
 
 async function logout() {
   try {
-    await auth.signOut();
+    await signOut(auth);
     console.log("✅ Logged out");
     window.location.href = "login.html";
   } catch (err) {
     console.error("❌ Logout error:", err);
+    alert("Logout failed: " + err.message);
   }
 }
 

--- a/signup.js
+++ b/signup.js
@@ -1,4 +1,4 @@
-import { auth } from './firebase.js';
+import { auth, createUserWithEmailAndPassword } from './firebase.js';
 
 async function signUp() {
   const email = document.getElementById("email").value.trim();
@@ -21,7 +21,7 @@ async function signUp() {
   }
 
   try {
-    const result = await auth.createUserWithEmailAndPassword(email, password);
+    const result = await createUserWithEmailAndPassword(auth, email, password);
     console.log("✅ Sign up successful:", result.user.email);
     alert("Account created! Please log in.");
     window.location.href = "login.html";


### PR DESCRIPTION
Fix Firebase v9+ modular SDK usage. Functions like createUserWithEmailAndPassword should be imported and called as standalone functions, not as methods on the auth object.